### PR TITLE
Update XPI main file path in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,12 +42,11 @@ var rootBuildDir = 'dist',
 		},
 		firefox: {
 			buildFolder: 'XPI',
-			manifest: 'XPI/lib/main.js',
+			manifest: 'XPI/index.js',
 			buildFiles: [
 				{ dest: 'data', src: ['XPI/data/**/*'] },
 				{ dest: 'data', src: commonFiles },
-				{ dest: 'lib',  src: ['XPI/lib/**/*'] },
-				{ dest: '/',    src: ['*.png', 'XPI/package.json'] }
+				{ dest: '/',    src: ['*.png', 'XPI/package.json', 'XPI/index.js'] }
 			]
 		},
 		oblink: {


### PR DESCRIPTION
Since commit 24d772caa2fa056f73bbe01bbe8393a9e8b72b35 `gulp -b firefox` does not create main file because XPI/lib/main.js was moved to XPI/index.js but gulpfile.js was not updated.